### PR TITLE
Remove "Updated" date from results list

### DIFF
--- a/src/Components/ResultsList.jsx
+++ b/src/Components/ResultsList.jsx
@@ -9,11 +9,9 @@ const ResultsList = (props) => {
       <p className="totalMessage"><strong>{props.total}</strong> results</p>
       
       { props.results.map(item => {
-        let updatedDate = new Date(parseInt(item.changed)).toDateString()
         return (
           <div className="anItem" key={item.id}>
             <a href={item.link}>{item.title}</a>
-            <p>Updated {updatedDate}</p>
             <p>{item.summary}</p>
           </div>
         )


### PR DESCRIPTION
Currently, they all appear as "Mon Jan 19 1970", and it'll be best to remove for now.