### PR TITLE
[11749] Add `types` to filter categories

### DIFF
--- a/src/Components/Checkbox.jsx
+++ b/src/Components/Checkbox.jsx
@@ -24,7 +24,6 @@ class Checkbox extends Component {
 
   componentDidMount() {
     if (getAppliedFilters(this.props.location.search)[this.props.category]) {
-      // if (getAppliedFilters(this.props.location.search)[this.props.category].includes(this.props.item["key"])) {
       if (getAppliedFilters(this.props.location.search)[this.props.category].includes(this.props.item)) {
         this.setState({ isChecked: true })
       } else { 
@@ -43,12 +42,20 @@ class Checkbox extends Component {
     }
   }
 
+  snakeToTitleCase (snake) {
+    return snake.replace(/([_][a-z])/ig, ($1) => {
+      return $1.toUpperCase()
+        .replace('_', ' ');
+    }).replace(/(^[a-z]{1})/ig, ($1) => {
+      return $1.toUpperCase()
+    })
+  }
+
   render() {
     const { key, category, item } = this.props;
-    // const value = item["key"];
     return (
       <label key={key}>
-        <input type="checkbox" name={category} value={item} key={key} onChange={(event) => this.handleToggleFilter(event)} checked={this.state.isChecked} /> {item}
+        <input type="checkbox" name={category} value={item} key={key} onChange={(event) => this.handleToggleFilter(event)} checked={this.state.isChecked} /> {(category === "types") ? (this.snakeToTitleCase(item)) : (item)}
       </label>
     )
   }

--- a/src/Components/CheckboxCategory.jsx
+++ b/src/Components/CheckboxCategory.jsx
@@ -42,26 +42,26 @@ class CheckboxCategory extends Component {
   render() {
     const itemArray = this.props.items.sort((a, b) => a["key"] > b["key"] ? 1 : -1).map(i => i["key"]);
     const uniqItemArray = [...new Set(itemArray)]
-    // console.log('uniqItemArray', uniqItemArray);
     return (
-      <details className="FilterCategory" open>
-      <summary>{filterTitles[this.props.category]}</summary>
 
-      { ((uniqItemArray.length > this.props.limit) && (!this.state.showAll)) ? (
-        uniqItemArray.slice(0, this.props.limit).map((item, i) => {
-          return (
-            <Checkbox key={i} category={this.props.category} item={item} uniqStr={this.props.uniqStr}/>
-          )
-        })
-      ) : (
-        uniqItemArray.map((item, i) => {
-          return (
-            <Checkbox key={i} category={this.props.category} item={item} uniqStr={this.props.uniqStr}/>
-          )
-        })
-      )}
-      {this.toggleShowButton(uniqItemArray.length)}
-      </details>
+      (uniqItemArray.length === 0) ? ( null ) : (
+
+        <details className="FilterCategory" open>
+        <summary id={filterTitles[this.props.category]}>{filterTitles[this.props.category]}</summary>
+
+        { ((uniqItemArray.length > this.props.limit) && (!this.state.showAll)) ? (
+          uniqItemArray.slice(0, this.props.limit).map((item, i) => {
+            return <Checkbox key={i} category={this.props.category} item={item} uniqStr={this.props.uniqStr}/>
+          })
+        ) : (
+          uniqItemArray.map((item, i) => {
+            return <Checkbox key={i} category={this.props.category} item={item} uniqStr={this.props.uniqStr}/>
+          })
+        )}
+        {this.toggleShowButton(uniqItemArray.length)}
+        </details>
+      )
+
     )
   }
 }
@@ -72,4 +72,5 @@ const filterTitles = {
   trade_topics: "Trade Topics",
   industries: "Industries",
   countries: "Countries",
+  types: "Type",
 }

--- a/src/Components/FiltersContainer.jsx
+++ b/src/Components/FiltersContainer.jsx
@@ -26,19 +26,26 @@ function FiltersContainer(props) {
     /* It's wierd, I know.  But "document.querySelectorAll('input[type=checkbox]').forEach( el => el.checked = false )" doesn't work because they're controlled components and are not connected to the redux store */
   }
 
+  function filterItemsForMarketIntel(category, items) {
+    if (category === 'types') {
+      return items.filter(obj => obj['key'] === 'market_intelligence')
+    } else { return items }
+  }
+
   function filterCategories() {
     return (
       // eslint-disable-next-line array-callback-return
       listCategories().map((cat, i) => {
         if (props.aggregations[cat].length) {
-          return (<CheckboxCategory category={cat} key={i} items={props.aggregations[cat]} limit={5} uniqStr={uniqStr} />)
+          const items = filterItemsForMarketIntel(cat, props.aggregations[cat])
+          return (<CheckboxCategory category={cat} key={i} items={items} limit={5} uniqStr={uniqStr} />)
         }
       })
     )
   }
 
   return(
-    <div className="FiltersContainer">
+    <div className='FiltersContainer'>
       { (props.aggregations !== {}) ? (
         <>
           <div><h2>Filter Results</h2><button onClick={() => handleClearFilters()}>[Clear All]</button></div>

--- a/src/store/actions/actions.js
+++ b/src/store/actions/actions.js
@@ -37,7 +37,7 @@ export const toggleFilter = (category, value, query_string) => {
 export const updateAggregations = (query_string, response, category) => {
   return (dispatch) => {
     let aggsToUpdate = [];
-    const categories_array = ['trade_topics', 'industries', 'countries'];
+    const categories_array = ['trade_topics', 'industries', 'countries', 'types'];
 
     categories_array.forEach(
       (cat) => {


### PR DESCRIPTION
- In the Type category, only display the checkbox for Market Intelligence.
  - Hide other types, and hide that whole category if it doesn't contain Market Intelligence.
- Display content type checkbox label in Title Case instead of snake_case